### PR TITLE
Docker上でスクリプトを動くようにした

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:lts-alpine
+
+COPY . .
+
+RUN npm install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+run:
+	docker build -t firebase-auth-generate-token -f ./Dockerfile .
+	docker run -it firebase-auth-generate-token npm run start

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 run:
-	docker build -t firebase-auth-generate-token -f ./Dockerfile .
-	docker run -it firebase-auth-generate-token npm run start
+	docker-compose build node
+	docker-compose run --rm node

--- a/README.md
+++ b/README.md
@@ -7,17 +7,7 @@ This is a very simple NodeJs script to generate the Firebase access token from e
 Clone the repository.
 
 ```
-git clone https://github.com/tregismoreira/firebase-auth-generate-token.git
-```
-
-Install the dependencies.
-
-```
-# with Yarn
-yarn
-
-# or with NPM
-npm install
+git clone https://github.com/tkm-kj/firebase-auth-generate-token.git
 ```
 
 Create a `.env` file in the root directory of your project and paste your Firebase credentials.
@@ -31,11 +21,7 @@ FIREBASE_PROJECT_ID=
 Start the script.
 
 ```
-# with Yarn
-yarn start
-
-# or with NPM
-npm run start
+make
 ```
 
 Once you run the script, you will be prompted the email and password. If the credentials are correct, the script will return the access token.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.7"
+services:
+  node:
+    build: .
+    env_file: .env
+    command: [npm, run, start]


### PR DESCRIPTION
dev, stage, prodの .env の設定について
`FIREBASE_API_KEY` はリンクの「ウェブ API キー」を参照すること

# dev

FIREBASE_API_KEY= https://console.firebase.google.com/u/1/project/vmedia-dev/settings/general/android:jp.voicy.app.player 参照
FIREBASE_AUTH_DOMAIN=vmedia-dev.firebaseapp.com
FIREBASE_PROJECT_ID=vmedia-dev

# stage

FIREBASE_API_KEY= https://console.firebase.google.com/u/1/project/vmedia-stage/settings/general/android:jp.voicy.app.player 参照
FIREBASE_AUTH_DOMAIN=vmedia-stage.firebaseapp.com
FIREBASE_PROJECT_ID=vmedia-stage

# prod

FIREBASE_API_KEY= https://console.firebase.google.com/u/1/project/vmedia-prod/settings/general/android:jp.voicy.app.player 参照
FIREBASE_AUTH_DOMAIN=vmedia-prod.firebaseapp.com
FIREBASE_PROJECT_ID=vmedia-prod